### PR TITLE
Fixed model selection issue in ModelSelect component

### DIFF
--- a/components/Chat/ModelSelect.tsx
+++ b/components/Chat/ModelSelect.tsx
@@ -1,5 +1,5 @@
 import { IconExternalLink } from '@tabler/icons-react';
-import { useContext, useState } from 'react';
+import { useContext, useState, useEffect } from 'react';
 
 import { useTranslation } from 'next-i18next';
 
@@ -56,6 +56,25 @@ export const ModelSelect = () => {
       });
     }
   };
+
+  useEffect(() => {
+    if (selectedConversation?.model) {
+      const model = models.find(
+        (m) => m.name === selectedConversation.model.name,
+      );
+      if (model) {
+        setSelectedModelDetails({
+          size: bytesToGB(model.size),
+          modified: timeAgo(new Date(model.modified_at)),
+        });
+      }
+    } else if (models.length > 0) {
+      setSelectedModelDetails({
+        size: bytesToGB(models[0].size),
+        modified: timeAgo(new Date(models[0].modified_at)),
+      });
+    }
+  }, [selectedConversation, models]);
 
   return (
     <div className="flex flex-col">


### PR DESCRIPTION
The model selector cannot handle the case where no llama:latest model is available, and only a single ollama model was available, when creating a new conversation.
Tries to default to llama:latest, but it does not exist, and dropdown selector does not allow selection of existing model.
Added useEffect to use whatever model is available.

<img width="708" alt="Screenshot 2023-10-06 at 11 03 21 PM" src="https://github.com/ivanfioravanti/chatbot-ollama/assets/81782870/f699afe2-d04a-4f2d-be63-4bd7a6bafec9">

<img width="652" alt="Screenshot 2023-10-06 at 11 04 51 PM" src="https://github.com/ivanfioravanti/chatbot-ollama/assets/81782870/61701567-b26c-4140-878c-eceaf11cd2de">
