### PR TITLE
Fixed toast overflow issue

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -14,7 +14,14 @@ function App({ Component, pageProps }: AppProps<{}>) {
 
   return (
     <div className={inter.className}>
-      <Toaster />
+      <Toaster
+        toastOptions={{
+          style: {
+            maxWidth: 500,
+            wordBreak: 'break-all',
+          },
+        }}
+      />
       <QueryClientProvider client={queryClient}>
         <Component {...pageProps} />
       </QueryClientProvider>


### PR DESCRIPTION
This was bugging me, long error strings were overflowing the toast notification.
Expanded the toast width a bit and added in forced word-break for very long strings

<img width="570" alt="Screenshot 2023-10-07 at 1 50 04 PM" src="https://github.com/ivanfioravanti/chatbot-ollama/assets/81782870/1f89f81c-6b1a-4440-b212-ec01e517b791">
