### PR TITLE
added type declaration on getModels(), to resolve type error

### DIFF
--- a/services/useApiService.ts
+++ b/services/useApiService.ts
@@ -2,12 +2,14 @@ import { useCallback } from 'react';
 
 import { useFetch } from '@/hooks/useFetch';
 
+import {OllamaModel, OllamaModelDetail} from '@/types/ollama'
+
 
 const useApiService = () => {
   const fetchService = useFetch();
 
   const getModels = useCallback(
-    () => {
+    (): Promise<OllamaModel[]>  => {
       return fetchService.get(`/api/models`, {
         headers: {
           'Content-Type': 'application/json',


### PR DESCRIPTION
Was getting a typescript build error since the type of data returned by this method couldn't be inferred.
Used your existing OllamaModel type to declare return type of getModels()