### PR TITLE
doc: fix typo `npm i` => `npm ci`

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ git clone https://github.com/ivanfioravanti/chatbot-ollama.git
 ### 2. Install Dependencies
 
 ```bash
-npm i
+npm ci
 ```
 
 ### 3. Run Ollama server


### PR DESCRIPTION
`npm i` (_dirty_ install) tells npm to ignore `package-lock.json` and instead install random versions of packages - a.k.a. _Works on My Machine™_.

`npm ci` (`clean-install`) is the correct command, which only installs the versions outlined in `package-lock.json` - _Works on Your Machine Too™_.

The default behavior of a dirty install exists for historical reasons, but leads to unintuitive and unexpected behavior (namely that most people believe and expect that they're getting the same versions as defined by the publisher in `package-lock.json`.

Now, the behavior most people actually _want_ is `npm clean-install && npm audit fix`, but that also spits out scary messages - which users _don't_ want. 🤷‍♂️